### PR TITLE
feat: add simple Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:10
+WORKDIR /app
+COPY . ./
+RUN yarn
+EXPOSE 9000
+CMD ["node", "index.js", "start"]


### PR DESCRIPTION
Currently must be configured before building so it will pick up xrp etc... But I got it working with two connectors sharing a payment channel by building with two different configs.

This setup could be handled in the future through moneyd-gui and the build can be stateless